### PR TITLE
test: MergeRoleGroupSpec method can be modified directly on the passed roleGroup object

### DIFF
--- a/pkg/reconciler/role.go
+++ b/pkg/reconciler/role.go
@@ -96,6 +96,7 @@ func (r *BaseRoleReconciler[T]) RegisterResources(ctx context.Context) error {
 // If a field exists in the left but is zero, it will be replaced by the corresponding field from the right.
 // The left must be a pointer, as the merge operation modifies it.
 // The fields "RoleGroups" and "PodDisruptionBudget" are excluded during the merge.
+// You don't need to use the return value of this method because it directly modifies the passed roleGroup.
 //
 // Example:
 //

--- a/pkg/reconciler/role_test.go
+++ b/pkg/reconciler/role_test.go
@@ -425,7 +425,6 @@ var _ = Describe("Role reconciler", func() {
 			Expect(roleReconciler).ToNot(BeNil())
 
 			By("merge role group spec")
-
 			roleGroupValue := roleReconciler.MergeRoleGroupSpec(roleGroupOne)
 			Expect(roleGroupValue).ToNot(BeNil())
 
@@ -455,7 +454,6 @@ var _ = Describe("Role reconciler", func() {
 			Expect(roleReconciler).ToNot(BeNil())
 
 			By("merge role group spec")
-
 			roleGroupValue := roleReconciler.MergeRoleGroupSpec(roleGroupTwo)
 			Expect(roleGroupValue).ToNot(BeNil())
 
@@ -471,6 +469,30 @@ var _ = Describe("Role reconciler", func() {
 
 			By("checking role.EnvOverrides merged")
 			Expect(roleGroup.EnvOverrides).To(Equal(role.EnvOverrides))
+		})
+
+		It("should merge itself", func() {
+			By("creating a role reconciler")
+			roleReconciler := NewRoleReconciler(
+				resourceClient,
+				roleInfo,
+				&commonsv1alpha1.ClusterOperationSpec{},
+				&ClusterConfigSpec{},
+				*role,
+			)
+
+			By("merge role group spec")
+			roleReconciler.MergeRoleGroupSpec(roleGroupOne)
+
+			By("checking role.Config merged")
+			Expect(roleGroupOne.Config.GracefulShutdownTimeout).To(Equal(role.Config.GracefulShutdownTimeout))
+
+			By("checking role.CommandOverrides not merged")
+			Expect(roleGroupOne.CommandOverrides).ToNot(Equal(role.CommandOverrides))
+
+			By("checking role.EnvOverrides merged")
+			Expect(roleGroupOne.EnvOverrides).To(Equal(role.EnvOverrides))
+
 		})
 	})
 })


### PR DESCRIPTION

## before

```go

// RegisterResources registers resources with T
func (r *RoleReconciler) RegisterResources(ctx context.Context) error {
	for roleGroupName, roleGroupSpec := range r.Spec.RoleGroups {

		mergedRoleGroup := r.MergeRoleGroupSpec(&roleGroupSpec)

		info := reconciler.RoleGroupInfo{
			RoleInfo:      r.RoleInfo,
			RoleGroupName: roleGroupName,
		}

		reconcilers, err := r.getResourceWithRoleGroup(ctx, info, mergedRoleGroup)
		if err != nil {
			return err
		}

		for _, reconciler := range reconcilers {
			r.AddResource(reconciler)
			roleLogger.Info("register resource", "role", r.GetName(), "roleGroup", roleGroupName, "reconciler", reconciler.GetName())
		}
	}
	return nil
}

func (r *RoleReconciler) getResourceWithRoleGroup(_ context.Context, info reconciler.RoleGroupInfo, roleGroupSpec any) ([]reconciler.Reconciler, error) {

	// roleGroupSpec convert to TrinoRoleGroupSpec
	roleGroup := roleGroupSpec.(*TrinoRoleGroupSpec)	// Must assert any type to TrinoRoleGroupSpec

	reconcilers := []reconciler.Reconciler{}

	reconcilers = append(reconcilers, r.getServiceReconciler(info))

	deploymentReconciler, err := r.getDeployment(info, roleGroup)
	if err != nil {
		return nil, err
	}

	reconcilers = append(reconcilers, deploymentReconciler)

	return reconcilers, nil
}
```

## after

```go

// RegisterResources registers resources with T
func (r *RoleReconciler) RegisterResources(ctx context.Context) error {
	for roleGroupName, roleGroup := range r.Spec.RoleGroups {
		// mergedRoleGroup := roleGroup.DeepCopy()
		mergedRoleGroup := &roleGroup
		r.MergeRoleGroupSpec(mergedRoleGroup)

		info := reconciler.RoleGroupInfo{
			RoleInfo:      r.RoleInfo,
			RoleGroupName: roleGroupName,
		}

		reconcilers, err := r.getResourceWithRoleGroup(ctx, info, mergedRoleGroup)
		if err != nil {
			return err
		}

		for _, reconciler := range reconcilers {
			r.AddResource(reconciler)
			roleLogger.Info("register resource", "role", r.GetName(), "roleGroup", roleGroupName, "reconciler", reconciler.GetName())
		}
	}
	return nil
}

func (r *RoleReconciler) getResourceWithRoleGroup(_ context.Context, info reconciler.RoleGroupInfo, roleGroupSpec *TrinoRoleGroupSpec) ([]reconciler.Reconciler, error) {

	reconcilers := []reconciler.Reconciler{}

	reconcilers = append(reconcilers, r.getServiceReconciler(info))

	deploymentReconciler, err := r.getDeployment(info, roleGroupSpec)
	if err != nil {
		return nil, err
	}

	reconcilers = append(reconcilers, deploymentReconciler)

	return reconcilers, nil
}
```