### PR TITLE
feat: add directory constants for kubedoop system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,5 +187,11 @@ Temporary Items
 bin/
 testbin/
 
-**/coverage/
-**/cover*
+# test
+ginkgo.report
+cover.out
+*__debug*
+**/coverage
+
+# ai code local
+.codiumai.toml

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,6 +14,19 @@ const (
 	ZncdataDomain = "zncdata.dev"
 )
 
+const (
+	KubedoopRoot = "/kubedoop"
+
+	KubedoopKerberosDir    = KubedoopRoot + "/kerberos"
+	KubedoopTlsDir         = KubedoopRoot + "/tls"
+	KubedoopListenerDir    = KubedoopRoot + "/listener"
+	KubedoopDataDir        = KubedoopRoot + "/data"
+	KubedoopConfigDir      = KubedoopRoot + "/config"
+	KubedoopLogDir         = KubedoopRoot + "/log"
+	KubedoopConfigDirMount = KubedoopRoot + "/mount/config"
+	KubedoopLogDirMount    = KubedoopRoot + "/mount/log"
+)
+
 func MatchingLabelsNames() []string {
 	return []string{
 		LabelKubernetesName,


### PR DESCRIPTION
- Introduced constants to standardize directory paths within the kubedoop module.
- Defined root directory as KubedoopRoot with value "/kubedoop".
- Added sub-directory constants:
  - KubedoopKerberosDir: "/kubedoop/kerberos"
  - KubedoopTlsDir: "/kubedoop/tls"
  - KubedoopListenerDir: "/kubedoop/listener"
  - KubedoopDataDir: "/kubedoop/data"
  - KubedoopConfigDir: "/kubedoop/config"
  - KubedoopLogDir: "/kubedoop/log"
  - KubedoopConfigDirMount: "/kubedoop/mount/config"
  - KubedoopLogDirMount: "/kubedoop/mount/log"
- This change enhances code maintainability and reduces redundancy in directory path definitions.
