### PR TITLE
refactor(api): remove kubebuilder validation tags to fix CR installation failure

### DIFF
--- a/pkg/apis/commons/v1alpha1/config_types.go
+++ b/pkg/apis/commons/v1alpha1/config_types.go
@@ -25,8 +25,6 @@ type RoleConfigSpec struct {
 
 type RoleGroupConfigSpec struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:pruning:PreserveUnknownFields
-	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:validation:Type=object
 	Affinity *k8sruntime.RawExtension `json:"affinity,omitempty"`
 	// +kubebuilder:validation:Optional

--- a/pkg/apis/commons/v1alpha1/overrides_types.go
+++ b/pkg/apis/commons/v1alpha1/overrides_types.go
@@ -28,8 +28,6 @@ type OverridesSpec struct {
 	// +kubebuilder:validation:Optional
 	ConfigOverrides map[string]map[string]string `json:"configOverrides,omitempty"`
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:pruning:PreserveUnknownFields
-	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:validation:Type=object
 	PodOverrides *k8sruntime.RawExtension `json:"podOverrides,omitempty"`
 }


### PR DESCRIPTION
- Removed `// +kubebuilder:pruning:PreserveUnknownFields`
- Removed `// +kubebuilder:validation:EmbeddedResource`
